### PR TITLE
Update nrel_between.scs

### DIFF
--- a/kb/plane_geometry/relation/nrel_between.scs
+++ b/kb/plane_geometry/relation/nrel_between.scs
@@ -17,6 +17,3 @@ nrel_between => nrel_idtf: [Ролевое отношение, связываю�
 nrel_between <- relation;;
 
 nrel_between <- quasybinary_relation;;
-
-nrel_between => 
-


### PR DESCRIPTION
Сборщик не мог распарсить файл, из-за того, что scs предложение было составленно неверно в последней строке